### PR TITLE
Fixed minor bug in parsing of TIFF file metadata.

### DIFF
--- a/ca_source_extraction/endoscope/tif2mat.m
+++ b/ca_source_extraction/endoscope/tif2mat.m
@@ -19,7 +19,7 @@ end
 info = imfinfo(nam);
 
       
-if  isfield(info(1), 'ImageDescription') && strfind(info(1).ImageDescription,'ImageJ')
+if  isfield(info(1), 'ImageDescription') && ~isempty(strfind(info(1).ImageDescription,'ImageJ'))
     junk1=regexp(info(1).ImageDescription,'images=\d*','match');
     junk2=strjoin(junk1);
     T=strread(junk2,'%*s %d','delimiter','=');

--- a/ca_source_extraction/utilities/smod_bigread2.m
+++ b/ca_source_extraction/utilities/smod_bigread2.m
@@ -38,7 +38,7 @@ if strcmpi(ext,'.tiff') || strcmpi(ext,'.tif');
     % end
     
     
-    if isfield(info(1), 'ImageDescription') && strfind(info(1).ImageDescription,'ImageJ')
+    if isfield(info(1), 'ImageDescription') && ~isempty(strfind(info(1).ImageDescription,'ImageJ'))
         junk1=regexp(info(1).ImageDescription,'images=\d*','match');
         junk2=strjoin(junk1);
         aa=strread(junk2,'%*s %d','delimiter','=');


### PR DESCRIPTION
When ImageDescription of a TIFF file is not empty the error "Operands to the || and && operators must be convertible to logical scalar values." is raised upon loading. This commit fixes that issue.