### PR TITLE
BUGFIX: Modified reconstruct_background to access correct frame range

### DIFF
--- a/ca_source_extraction/@Sources2D/Sources2D.m
+++ b/ca_source_extraction/@Sources2D/Sources2D.m
@@ -1,11 +1,11 @@
 classdef Sources2D < handle
-    
+
     % This class is a wrapper of Constrained NMF for standard 2D data. It
     % Both CNMF and CNMF-E model can be used.
-    
+
     % Author: Pengcheng Zhou, Columbia University, 2017
     % zhoupc1988@gmail.com
-    
+
     %% properties
     properties
         % spatial
@@ -22,7 +22,7 @@ classdef Sources2D < handle
         f;          % temporal components of backgrounds
         W;          % a sparse weight matrix matrix
         b0;         % constant baselines for each pixel
-        b0_new;  % correct the changes in b0 when we update A & C 
+        b0_new;  % correct the changes in b0 when we update A & C
         % optiosn
         options;    % options for model fitting
         P;          % some estimated parameters or parameters relating to data
@@ -42,20 +42,20 @@ classdef Sources2D < handle
         % when temporal traces are random noise
         % a4 = 1 indicates that the CNMF-E fails in deconvolving temporal
         % traces. this usually happens when neurons are false positives.
-        
+
         % a4 = 1 indicates that the neuron has small PNR
         %others
         Cn;         % correlation image
         PNR;        % peak-to-noise ratio image.
         Coor;       % neuron contours
-        neurons_per_patch; 
+        neurons_per_patch;
         Df;         % background for each component to normalize the filtered raw data
         C_df;       % temporal components of neurons and background normalized by Df
         S_df;       % spike counts of neurons normalized by Df
         batches = cell(0);  % results for each small batch data
         file_id = [];    % file id for each batch.
     end
-    
+
     %% methods
     methods
         %% constructor and options setting
@@ -69,19 +69,19 @@ classdef Sources2D < handle
             end
             obj.kernel = create_kernel('exp2');
         end
-        
+
         %------------------------------------------------------------------OPTIONS------------%
         %% update parameters
         function updateParams(obj, varargin)
             obj.options = CNMFSetParms(obj.options, varargin{:});
         end
-        
+
         %------------------------------------------------------------------PREPROCESSING-------%
         %% data preprocessing
         function Y = preprocess(obj,Y,p)
             [obj.P,Y] = preprocess_data(Y,p,obj.options);
         end
-        
+
         %------------------------------------------------------------------LOAD DATA-----------%
         %% select data
         function nam = select_data(obj, nam)
@@ -100,8 +100,8 @@ classdef Sources2D < handle
                 nam =  get_fullname(nam);
                 [dir_nm, ~, ~] = fileparts(nam);
             end
-            
-            
+
+
             if dir_nm~=0
                 try
                     save .dir.mat dir_nm;
@@ -114,7 +114,7 @@ classdef Sources2D < handle
             end
             obj.file = nam;
         end
-        
+
         %% select multiple datasets
         function nams = select_multiple_files(obj, nams)
             if ~isempty(nams)
@@ -127,7 +127,7 @@ classdef Sources2D < handle
                         nams{m} = get_fullname(nams{m});
                     end
                 end
-                
+
                 nams = nams(ind_keep);
                 fprintf('\n----------------------------------------\n');
                 for m=1:length(nams)
@@ -136,7 +136,7 @@ classdef Sources2D < handle
                 fprintf('\n----------------------------------------\n');
                 obj.file = nams;
                 return;
-                
+
             end
             fprintf('\t-------------------------- GUIDE --------------------------\n');
             fprintf('\ttype -i to remove the selected i-th file\n');
@@ -156,18 +156,18 @@ classdef Sources2D < handle
                             ind_keep = false;
                         end
                     end
-                    
+
                     nams = nams(ind_keep);
                     fprintf('\n----------------------------------------\n');
                     for m=1:length(nams)
                         fprintf('%d:\t%s\n', m, nams{m});
                     end
                     fprintf('\n----------------------------------------\n');
-                    
+
                 end
-                
+
                 % make choise
-                
+
                 your_ans = input('make  your choice: ');
                 if your_ans==0
                     break;
@@ -179,24 +179,24 @@ classdef Sources2D < handle
             end
             obj.file = unique(nams);
         end
-        
-        
-        %% load the patched file into the memory 
+
+
+        %% load the patched file into the memory
         function map_data_to_memory(obj)
-           mat_file = obj.P.mat_file; 
+           mat_file = obj.P.mat_file;
            if exist(mat_file, 'file')
                data_nam = sprintf('mat_data_%d', string2hash(mat_file));
                if isempty(evalin('base', sprintf('whos(''%s'')', data_nam)))
-                   % the data has not been mapped yet 
+                   % the data has not been mapped yet
                    evalin('base', sprintf('%s=load(''%s''); ', data_nam, mat_file));
                end
            end
         end
-        
+
         %% load data within selected patch position and selected frames
         function Ypatch = load_patch_data(obj, patch_pos, frame_range)
             mat_data = obj.P.mat_data;
-            
+
             dims = mat_data.dims;
             d1 = dims(1);
             d2 = dims(2);
@@ -227,13 +227,13 @@ classdef Sources2D < handle
                 memory_size_per_patch = pars_envs.memory_size_per_patch;
                 patch_dims = pars_envs.patch_dims;
             end
-            
+
             if ~exist('filter_kernel', 'var')
-                filter_kernel = []; 
-            end 
+                filter_kernel = [];
+            end
             % overlapping area
             w_overlap = obj.options.ring_radius;
-            
+
             % distribute data
             [data, dims, obj.P.folder_analysis] = distribute_data(nam,...
                 patch_dims, w_overlap, memory_size_per_patch, memory_size_to_use,...
@@ -242,7 +242,7 @@ classdef Sources2D < handle
             obj.P.mat_file = data.Properties.Source;
             obj.updateParams('d1', dims(1), 'd2', dims(2));
             obj.P.numFrames = dims(3);
-            
+
             % estimate the noise level for each pixel
             try
                 obj.P.sn = obj.P.mat_data.sn;
@@ -253,16 +253,16 @@ classdef Sources2D < handle
                 mat_data.sn = obj.P.sn;
                 mat_data.Properties.Writable = false;
             end
-            
+
             %% map the data to the memory
-            temp = cast(0, data.dtype); 
-            temp = whos('temp'); 
-            data_space = prod(data.dims) * temp.bytes / (2^30); 
+            temp = cast(0, data.dtype);
+            temp = whos('temp');
+            data_space = prod(data.dims) * temp.bytes / (2^30);
             if data_space < memory_size_to_use
                 obj.map_data_to_memory();
             end
         end
-        
+
         %% distribute data and be ready to run batch mode source extraction
         function getReady_batch(obj, pars_envs, log_folder)
             %% parameters for scaling things
@@ -285,7 +285,7 @@ classdef Sources2D < handle
             batches_ = cell(100, 1);
             file_id_ = zeros(100,1, 'like', uint8(1));
             numFrames = zeros(100,1);
-            
+
             k_batch = 0;
             for m=1:length(nams)
                 neuron = obj.copy();
@@ -305,7 +305,7 @@ classdef Sources2D < handle
                     frame_range_t = round(linspace(1, T, nbatches+1));
                 end
                 nbatches = length(frame_range_t) -1;
-                
+
                 for n=1:nbatches
                     k_batch = k_batch +1;
                     tmp_neuron = neuron.copy();
@@ -317,12 +317,12 @@ classdef Sources2D < handle
                     numFrames(k_batch) = diff(tmp_neuron.frame_range)+1;
                 end
             end
-            
+
             obj.batches = batches_(1:k_batch);
             obj.file_id = file_id_(1:k_batch);
             obj.P.numFrames = numFrames(1:k_batch);
         end
-        
+
         %% estimate noise
         function sn = estimate_noise(obj, frame_range, method)
             mat_data = obj.P.mat_data;
@@ -376,8 +376,8 @@ classdef Sources2D < handle
             fprintf('Time cost for estimating the nosie levels:  %.3f \n\n', toc);
             sn = cell2mat(sn);
         end
-        
-        
+
+
         %% pick parameters
         [gSig, gSiz, ring_radius, min_corr, min_pnr] = set_parameters(obj)
         %------------------------------------------------------------------INITIALIZATION-----------%
@@ -386,97 +386,97 @@ classdef Sources2D < handle
             if nargin<4 ;    tau = [];             end
             [obj.A, obj.C, obj.b, obj.f, center] = initialize_components(Y, K, tau, obj.options);
         end
-        
+
         %% initialize neurons using patch method
         % for 1P and 2P data, CNMF and CNMF-E
         [center, Cn, PNR] = initComponents_parallel(obj, K, frame_range, save_avi, use_parallel, use_prev)
-        
+
         %% initialize neurons for multiple batches
         % for 1P and 2P data, CNMF and CNMF-E
         [center, Cn, PNR] = initComponents_batch(obj, K, frame_range, save_avi, use_parallel)
-        
+
         %% fast initialization for microendoscopic data
         [center, Cn, pnr] = initComponents_endoscope(obj, Y, K, patch_sz, debug_on, save_avi);
-        
+
         [center] = initComponents_2p(obj,Y, K, options, sn, debug_on, save_avi);
-        
+
         %% pick neurons from the residual
         % for 1P and 2P data, CNMF and CNMF-E
         [center, Cn, PNR] = initComponents_residual_parallel(obj, K, save_avi, use_parallel, min_corr, min_pnr, seed_method)
-        
+
         %------------------------------------------------------------------UPDATE MODEL VARIABLES---%
         %% update background components in parallel
         % for 1P and 2P data, CNMF and CNMF-E
         update_background_parallel(obj, use_parallel)
-        
+
         %% update  background for all batches
         update_background_batch(obj, use_parallel)
-        
+
         %% update spatial components in parallel
         % for 1P and 2P data, CNMF and CNMF-E
         update_spatial_parallel(obj, use_parallel, update_sn)
-        
+
         %% update spatial components in batch mode
         update_spatial_batch(obj, use_parallel);
-        
+
         %% update temporal components in parallel
         % for 1P and 2P data, CNMF and CNMF-E
         update_temporal_parallel(obj, use_parallel, use_c_hat)
-        
+
         %% update temporal components in batch mode
         % for 1P and 2P data, CNMF and CNMF-E
         update_temporal_batch(obj, use_parallel)
-        
+
         %% update spatial components, 2P data, CNMF
         function updateSpatial(obj, Y)
             [obj.A, obj.b, obj.C] = update_spatial_components(Y, ...
                 obj.C, obj.f, obj.A, obj.P, obj.options);
         end
-        
+
         %% udpate spatial components without background, no background components
         function updateSpatial_nb(obj, Y)
             [obj.A, obj.C] = update_spatial_components_nb(Y, ...
                 obj.C, obj.A, obj.P, obj.options);
         end
-        
+
         %% udpate spatial components using NNLS and thresholding
         function updateSpatial_nnls(obj, Y)
             [obj.A, obj.C] = update_spatial_nnls(Y, ...
                 obj.C, obj.A, obj.P, obj.options);
         end
-        
+
         %% update temporal components for endoscope data
         updateSpatial_endoscope(obj, Y, numIter, method, IND_thresh);
-        
+
         %% update temporal components
         function updateTemporal(obj, Y)
             [obj.C, obj.f, obj.P, obj.S] = update_temporal_components(...
                 Y, obj.A, obj.b, obj.C, obj.f, obj.P, obj.options);
         end
-        
+
         %% udpate temporal components with fast deconvolution
         updateTemporal_endoscope(obj, Y, allow_deletion)
         updateTemporal_endoscope_parallel(obj, Y, smin)
-        
+
         %% update temporal components without background
         function updateTemporal_nb(obj, Y)
             [obj.C, obj.P, obj.S] = update_temporal_components_nb(...
                 Y, obj.A, obj.b, obj.C, obj.f, obj.P, obj.options);
         end
-        
+
         %------------------------------------------------------------------MERGE NEURONS ---------%
         %% merge found components
         function [nr, merged_ROIs] = merge(obj, Y)
             [obj.A, obj.C, nr, merged_ROIs, obj.P, obj.S] = merge_components(...
                 Y,obj.A, [], obj.C, [], obj.P,obj.S, obj.options);
         end
-        
+
         %% quick merge neurons based on spatial and temporal correlation
         [merged_ROIs, newIDs] = quickMerge(obj, merge_thr)
-        
+
         %% quick merge neurons based on spatial and temporal correlation
         [merged_ROIs, newIDs] = MergeNeighbors(obj, dmin, method)
-        
+
         %------------------------------------------------------------------EXPORT---%
         function save_neurons(obj, folder_nm, with_craw)
             if ~exist('folder_nm', 'var') || isempty(folder_nm)
@@ -499,13 +499,13 @@ classdef Sources2D < handle
                 obj.viewNeurons([], [], folder_nm);
             end
         end
-        
+
         %% export the result as a video
         avi_filename = show_demixed_video(obj,save_avi, kt, frame_range, center_ac, range_ac, range_Y, multi_factor, use_craw)        %% compute the residual
         %         function [Y_res] = residual(obj, Yr)
         %             Y_res = Yr - obj.A*obj.C - obj.b*obj.f;
         %         end
-        
+
         %% take the snapshot of current results
         function [A, C,  b, f, P, S] = snapshot(obj)
             A = obj.A;
@@ -519,22 +519,22 @@ classdef Sources2D < handle
                 S = [];
             end
         end
-        
+
         %% extract DF/F signal after performing NMF
         function [C_df, Df, S_df] = extractDF_F(obj, Y, i)
             if ~exist('i', 'var')
                 i = size(obj.A, 2) + 1;
             end
-            
+
             [obj.C_df, obj.Df, obj.S_df] = extract_DF_F(Y, [obj.A, obj.b],...
                 [obj.C; obj.f], obj.S, i);
-            
+
             C_df =  obj.C_df;
             Df = obj.Df;
             S_df = obj.S_df;
-            
+
         end
-        
+
         %% extract DF/F signal for microendoscopic data
         function [C_df,C_raw_df, Df] = extract_DF_F_endoscope(obj, Ybg)
             options_ = obj.options;
@@ -567,7 +567,7 @@ classdef Sources2D < handle
                 C_raw_df = obj.C_raw./Df;
             end
         end
-        
+
         %% order_ROIs
         function [srt] = orderROIs(obj, srt)
             %% order neurons
@@ -578,7 +578,7 @@ classdef Sources2D < handle
                 srt='srt';
             end
             K = size(obj.C, 1);
-            
+
             if ischar(srt)
                 if strcmpi(srt, 'decay_time')
                     % time constant
@@ -626,18 +626,18 @@ classdef Sources2D < handle
             end
             obj.A = obj.A(:, srt);
             obj.C = obj.C(srt, :);
-            
+
             try
                 obj.C_raw = obj.C_raw(srt,:);
                 obj.S = obj.S(srt,:);
                 obj.P.kernel_pars = obj.P.kernel_pars(srt, :);
                 obj.P.neuron_sn = obj.P.neuron_sn(srt);
-                
+
                 obj.ids = obj.ids(srt);
                 obj.tags = obj.tags(srt);
             end
         end
-        
+
         %% view contours
         function [Coor, json_file] = viewContours(obj, Cn, contour_threshold, display, ind, ln_wd)
             if or(isempty(Cn), ~exist('Cn', 'var') )
@@ -650,7 +650,7 @@ classdef Sources2D < handle
                 contour_threshold, display, [], [], ln_wd);
             Coor = obj.Coor;
         end
-        
+
         %% plot components
         function plotComponents(obj, Y, Cn)
             if ~exist('Cn', 'var')
@@ -658,7 +658,7 @@ classdef Sources2D < handle
             end
             view_components(Y, obj.A, obj.C, obj.b, obj.f, Cn, obj.options);
         end
-        
+
         %% plot components GUI
         function plotComponentsGUI(obj, Y, Cn)
             if ~exist('Cn', 'var')
@@ -666,19 +666,19 @@ classdef Sources2D < handle
             end
             plot_components_GUI(Y,obj.A,obj.C,obj.b,obj.f,Cn,obj.options)
         end
-        
+
         %% make movie
         function makePatchVideo(obj, Y)
             make_patch_video(obj.A, obj.C, obj.b, obj.f, Y, obj.Coor,...
                 obj.options);
         end
-        
+
         %% down sample data and initialize it
         [obj_ds, Y_ds] = downSample(obj, Y)
-        
+
         %% up-sample the results
         upSample(obj, obj_ds, T);
-        
+
         %% copy the objects
         function obj_new = copy(obj)
             % Instantiate new object of the same class.
@@ -689,7 +689,7 @@ classdef Sources2D < handle
                 obj_new.(p{i}) = obj.(p{i});
             end
         end
-        
+
         %% concatenate results from multi patches
         function concatenate_temporal_batch(obj)
             T_k= obj.P.numFrames;
@@ -725,7 +725,7 @@ classdef Sources2D < handle
         %% quick view
         ind_del = viewNeurons(obj, ind, C2, folder_nm);
         displayNeurons(obj, ind, C2, folder_nm);
-        
+
         %% function remove false positives
         function ids = remove_false_positives(obj, show_delete)
             if ~exist('show_delete', 'var')
@@ -743,7 +743,7 @@ classdef Sources2D < handle
                 end
             end
         end
-        
+
         %% delete neurons
         function delete(obj, ind)
             % write the deletion into the log file
@@ -775,12 +775,12 @@ classdef Sources2D < handle
                     tmp_str = get_date();
                     tmp_str=strrep(tmp_str, '-', '_');
                     eval(sprintf('log_data.ids_del_%s = ids_del;', tmp_str));
-                    
+
                     fprintf(flog, '\tThe IDS of these neurons were saved as intermediate_results.ids_del_%s\n\n', tmp_str);
                 end
                 fclose(flog);
             end
-            
+
             obj.A(:, ind) = [];
             obj.C(ind, :) = [];
             if ~isempty(obj.S)
@@ -794,17 +794,17 @@ classdef Sources2D < handle
             end
             try  obj.ids(ind) = [];   catch;   end
             try obj.tags(ind) =[]; catch; end
-            
+
             % save the log
         end
-        
+
         %% merge neurons
-        
+
         %% estimate neuron centers
         function [center] = estCenter(obj)
             center = com(obj.A, obj.options.d1, obj.options.d2);
         end
-        
+
         %% update A & C using HALS
         function [obj, IDs] = HALS_AC(obj, Y)
             %update A,C,b,f with HALS
@@ -812,10 +812,10 @@ classdef Sources2D < handle
             [obj.A, obj.C, obj.b, obj.f, IDs] = HALS_2d(Y, obj.A, obj.C, obj.b,...
                 obj.f, obj.options);
         end
-        
+
         %% update backgrounds
         [B, F] = updateBG(obj, Y, nb, model)
-        
+
         %% reshape data
         function Y = reshape(obj, Y, dim)
             % reshape the imaging data into diffrent dimensions
@@ -827,13 +827,13 @@ classdef Sources2D < handle
                 Y = reshape(full(Y), d1, d2, []);    %each frame is an image
             end
         end
-        
+
         %% deconvolve all temporal components
         C_ = deconvTemporal(obj, use_parallel, method_noise)
-        
-        %% decorrelate all tmeporal components 
-        C_ = decorrTemporal(obj, wd); 
-        
+
+        %% decorrelate all tmeporal components
+        C_ = decorrTemporal(obj, wd);
+
         %% play movie
         function playMovie(obj, Y, min_max, col_map, avi_nm, t_pause)
             Y = double(Y);
@@ -886,14 +886,14 @@ classdef Sources2D < handle
                 avi_file.close();
             end
         end
-        
+
         %% export AVI
         function exportAVI(obj, Y, min_max, avi_nm, col_map)
             % export matrix data to movie
             %min_max: 1*2 vector, scale
             %avi_nm: string, file name
             %col_map: colormap
-            
+
             T = size(Y, ndims(Y));
             Y = Y(:);
             if ~exist('col_map', 'var') || isempty(col_map)
@@ -905,14 +905,14 @@ classdef Sources2D < handle
             if ~exist('min_max', 'var') || isempty(min_max)
                 min_max = [min(Y(1:10:end)), max(Y(1:10:end))];
             end
-            
+
             Y = uint8(64*(Y-min_max(1))/diff(min_max));
             Y(Y<1) = 1;
             Y(Y>64) = 64;
             col_map = uint8(255*col_map);
             Y = reshape(col_map(Y, :), obj.options.d1, [], T, 3);
             Y = permute(Y, [1,2,4,3]);
-            
+
             avi_file = VideoWriter(avi_nm);
             avi_file.open();
             for m=1:T
@@ -922,23 +922,23 @@ classdef Sources2D < handle
             end
             avi_file.close();
         end
-        
+
         %% trim spatial components
         function [ind_small] = trimSpatial(obj, thr, sz)
             % remove small nonzero pixels
             if nargin<2;    thr = 0.01; end
             if nargin<3;    sz = 5; end
-            
+
             se = strel('square', sz);
             ind_small = false(size(obj.A, 2), 1);
             for m=1:size(obj.A,2)
                 ai = obj.A(:,m);
                 ai_open = imopen(obj.reshape(ai,2), se);
-                
+
                 temp = full(ai_open>max(ai)*thr);
                 l = bwlabel(obj.reshape(temp,2), 4);   % remove disconnected components
                 [~, ind_max] = max(ai_open(:));
-                
+
                 ai(l(:)~=l(ind_max)) = 0;
                 if sum(ai(:)>0) < obj.options.min_pixel %the ROI is too small
                     ind_small(m) = true;
@@ -948,7 +948,7 @@ classdef Sources2D < handle
 %             ind_small = find(ind_small);
 %             obj.delete(ind_small);
         end
-        
+
         %% keep spatial shapes compact
         function compactSpatial(obj)
             for m=1:size(obj.A, 2)
@@ -957,7 +957,7 @@ classdef Sources2D < handle
                 obj.A(:, m) = ai(:);
             end
         end
-        
+
         %% solve A & C with regression
         function [ind_delete] = regressAC(obj, Y)
             if ~ismatrix(Y); Y=obj.reshape(Y,2); end
@@ -967,14 +967,14 @@ classdef Sources2D < handle
                 ind_nonzero = obj.trimSpatial(50); % remove tiny nonzero pixels
                 active_pixel = determine_search_location(A2, 'dilate', obj.options);
                 K = size(A2, 2); %number of neurons
-                
+
                 tmp_C = (A2'*A2)\(A2'*Y);        % update temporal components
                 tmp_C(tmp_C<0) = 0;
                 % %                 tmp_C(bsxfun(@gt, quantile(tmp_C, 0.95, 2), tmp_C)) = 0;
                 %                 tmp_C(bsxfun(@gt, mean(tmp_C, 2)+std(tmp_C, 0.0, 2), tmp_C)) = 0;
                 A2 = (Y*tmp_C')/(tmp_C*tmp_C');           % update spatial components
                 A2(or(A2<0, ~active_pixel)) = 0;
-                
+
                 for m=1:K
                     % remove disconnected pixels
                     img = obj.reshape(A2(:,m), 2);
@@ -982,7 +982,7 @@ classdef Sources2D < handle
                     img(lb~=mode(lb(ind_nonzero(:, m)))) = 0 ; %find pixels connected to the original components
                     A2(:,m) = img(:);
                 end
-                
+
                 center_ratio = sum(A2.*ind_nonzero, 1)./sum(A2, 1); %
                 % captured too much pixels, ignore newly captured pixels
                 ind_too_much = (center_ratio<0.4);
@@ -996,7 +996,7 @@ classdef Sources2D < handle
             temp(temp<0) = 0;
             obj.C = temp;
         end
-        
+
         %% regress A given C
         function [A2, ind_neuron] = regressA(obj, Y, C)
             if ~ismatrix(Y); Y=obj.reshape(Y,2); end
@@ -1004,10 +1004,10 @@ classdef Sources2D < handle
             ind_nonzero = obj.trimSpatial(50); % remove tiny nonzero pixels
             active_pixel = determine_search_location(A2, 'dilate', obj.options);
             K = size(A2, 2); %number of neurons
-            
+
             A2 = (Y*C')/(C*C');           % update spatial components
             A2(or(A2<0, ~active_pixel)) = 0;
-            
+
             for m=1:K
                 % remove disconnected pixels
                 img = obj.reshape(A2(:,m), 2);
@@ -1015,7 +1015,7 @@ classdef Sources2D < handle
                 img(lb~=mode(lb(ind_nonzero(:, m)))) = 0 ; %find pixels connected to the original components
                 A2(:,m) = img(:);
             end
-            
+
             center_ratio = sum(A2.*ind_nonzero, 1)./sum(A2, 1); %
             % captured too much pixels, ignore newly captured pixels
             ind_too_much = (center_ratio<0.3);
@@ -1027,7 +1027,7 @@ classdef Sources2D < handle
             ind_neuron = (1:K);
             ind_neuron(ind_delete) =[];
         end
-        
+
         %% view results
         function runMovie(obj, Y, min_max, save_avi, avi_name, S)
             ctr = obj.estCenter();
@@ -1036,7 +1036,7 @@ classdef Sources2D < handle
             if ~exist('S', 'var');  S = []; end
             run_movie(Y, obj.A, obj.C_raw, obj.Cn, min_max, obj.Coor, ctr, 5, 1, save_avi, avi_name, S)
         end
-        
+
         %% function
         function image(obj, a, min_max)
             if isvector(a); a = obj.reshape(a,2); end
@@ -1046,7 +1046,7 @@ classdef Sources2D < handle
                 imagesc(a, min_max);
             end
         end
-        
+
         %% normalize
         function normalize(obj)
             norm_A = max(obj.A, [], 1);
@@ -1054,7 +1054,7 @@ classdef Sources2D < handle
             tmp_C = bsxfun(@times, obj.C, norm_A');
             obj.A = tmp_A; obj.C = tmp_C;
         end
-        
+
         %% load data
         function [Y, neuron] = load_data(obj, nam, sframe, num2read)
             ssub = obj.options.ssub;    % spatial downsampling factor
@@ -1081,7 +1081,7 @@ classdef Sources2D < handle
                 img = squeeze(h5read(nam, dataset_nam, ones(1, ndims), [1,d1, d2, 1, 1]));
             end
             num2read = min(num2read, numFrame-sframe+1); % frames to read
-            
+
             if Tbatch>=num2read
                 % load all data because the file is too small
                 if strcmpi(file_type, '.mat')
@@ -1124,7 +1124,7 @@ classdef Sources2D < handle
             end
             neuron.options.min_pixel = ceil(obj.options.min_pixel/(ssub^2));
         end
-        
+
         %% estimate noise
         function sn = estNoise(obj, Y)
             fprintf('Estimating the noise power for each pixel from a simple PSD estimate...');
@@ -1133,13 +1133,13 @@ classdef Sources2D < handle
             obj.P.sn = sn(:);
             fprintf('  done \n');
         end
-        
+
         %% reconstruct baseline
         function b0_ = reconstruct_b0(obj)
             try
                 % map data
                 mat_data = obj.P.mat_data;
-                
+
                 % dimension of data
                 dims = mat_data.dims;
                 d1 = dims(1);
@@ -1147,7 +1147,7 @@ classdef Sources2D < handle
                 T = dims(3);
                 obj.options.d1 = d1;
                 obj.options.d2 = d2;
-                
+
                 % parameters for patching information
                 patch_pos = mat_data.patch_pos;
                 % number of patches
@@ -1157,7 +1157,7 @@ classdef Sources2D < handle
                 b0_= [];
                 return;
             end
-            
+
             b0_ = zeros(d1, d2);
             for mpatch=1:(nr_patch*nc_patch)
                 b0_patch = obj.b0{mpatch};
@@ -1169,13 +1169,13 @@ classdef Sources2D < handle
                 b0_(r0:r1, c0:c1) = reshape(b0_patch, r1-r0+1, c1-c0+1);
             end
         end
-        
+
         %% concatenate W
         function W = concatenate_W(obj)
             try
                 % map data
                 mat_data = obj.P.mat_data;
-                
+
                 % dimension of data
                 dims = mat_data.dims;
                 d1 = dims(1);
@@ -1183,7 +1183,7 @@ classdef Sources2D < handle
                 T = dims(3);
                 obj.options.d1 = d1;
                 obj.options.d2 = d2;
-                
+
                 % parameters for patching information
                 patch_pos = mat_data.patch_pos;
                 block_pos = mat_data.block_pos;
@@ -1213,17 +1213,17 @@ classdef Sources2D < handle
                 [ii1, ii2] = ind2sub([nr_patch, nc_patch], ii);
                 ii1 = ii1 + tmp_patch(1)-1;
                 ii2 = ii2 + tmp_patch(3)-1;
-                
+
                 [jj1, jj2] = ind2sub([nr_block, nc_block], jj);
                 jj1 = jj1 + tmp_block(1)-1;
                 jj2 = jj2 + tmp_block(3)-1;
-                
+
                 ii = sub2ind([d1, d2], ii1, ii2);
                 jj = sub2ind([d1, d2], jj1, jj2);
                 ii_all(k+(1:length(ii))) = ii;
                 jj_all(k+(1:length(jj))) = jj;
                 vv_all(k+(1:length(vv))) = vv;
-                
+
                 k = k + length(ii);
             end
             W = sparse(ii_all(1:k), jj_all(1:k), vv_all(1:k), d, d);
@@ -1235,13 +1235,13 @@ classdef Sources2D < handle
             %   frame_range:  [frame_start, frame_end], the range of frames to be loaded
             %% Author: Pengcheng Zhou, Columbia University, 2017
             %% email: zhoupc1988@gmail.com
-            
+
             %% process parameters
-            
+
             try
                 % map data
                 mat_data = obj.P.mat_data;
-                
+
                 % dimension of data
                 dims = mat_data.dims;
                 d1 = dims(1);
@@ -1249,31 +1249,32 @@ classdef Sources2D < handle
                 T = dims(3);
                 obj.options.d1 = d1;
                 obj.options.d2 = d2;
-                
+
                 % parameters for patching information
                 patch_pos = mat_data.patch_pos;
                 block_pos = mat_data.block_pos;
-                
+
                 % number of patches
                 [nr_patch, nc_patch] = size(patch_pos);
             catch
                 error('No data file selected');
             end
-            
+
             if ~exist('frame_range', 'var')||isempty(frame_range)
                 frame_range = obj.frame_range;
+                indices = (obj.frame_range(1) - frame_range(1) + 1):(obj.frame_range(2) - frame_range(1) + 1);
             end
             % frames to be loaded for initialization
             T = diff(frame_range) + 1;
-            
+
             bg_model = obj.options.background_model;
             bg_ssub = obj.options.bg_ssub;
             % reconstruct the constant baseline
             if strcmpi(bg_model, 'ring')
                 b0_ = obj.reconstruct_b0();
-                b0_new_ = obj.reshape(obj.b0_new, 2); 
+                b0_new_ = obj.reshape(obj.b0_new, 2);
             end
-            
+
             %% start updating the background
             Ybg = zeros(d1, d2, T);
             for mpatch=1:(nr_patch*nc_patch)
@@ -1289,23 +1290,23 @@ classdef Sources2D < handle
                     tmp_patch = patch_pos{mpatch};
                     b0_ring = b0_(tmp_block(1):tmp_block(2), tmp_block(3):tmp_block(4));
                     b0_ring = reshape(b0_ring, [], 1);
-                    
+
                     b0_patch = reshape(b0_new_(tmp_patch(1):tmp_patch(2), tmp_patch(3):tmp_patch(4)), [], 1);
-                    
+
                     % find the neurons that are within the block
                     mask = zeros(d1, d2);
                     mask(tmp_block(1):tmp_block(2), tmp_block(3):tmp_block(4)) = 1;
                     ind = (reshape(mask(:), 1, [])* obj.A_prev>0);
-                    
+
                     A_patch = obj.A_prev(logical(mask), ind);
-                    C_patch = obj.C_prev(ind, frame_range(1):frame_range(2));
-                    
+                    C_patch = obj.C_prev(ind, indices);
+
                     % reconstruct background
                     %                     Cmean = mean(C_patch , 2);
                     Ypatch = bsxfun(@minus, double(Ypatch), b0_ring);
 %                     b0_ring = b0_(tmp_patch(1):tmp_patch(2), tmp_patch(3):tmp_patch(4));
 %                     b0_ring = reshape(b0_ring, [], 1);
-%                     
+%
                     if bg_ssub==1
                         Bf = W_ring*(double(Ypatch) - A_patch*C_patch);
                         Ybg(tmp_patch(1):tmp_patch(2), tmp_patch(3):tmp_patch(4),:) = reshape(bsxfun(@plus, Bf, b0_patch), diff(tmp_patch(1:2))+1, [], T);
@@ -1329,11 +1330,11 @@ classdef Sources2D < handle
                     b0_svd = obj.b0{mpatch};
                     Ybg(tmp_patch(1):tmp_patch(2), tmp_patch(3):tmp_patch(4),:) = reshape(bsxfun(@plus, b_svd*f_svd(:, frame_range(1):frame_range(2)), b0_svd), diff(tmp_patch(1:2))+1, [], T);
                 end
-                
+
             end
-            
+
         end
-        
+
         % compute RSS
         function [RSS_total, RSS] = compute_RSS(obj, frame_range)
             %% compute RSS
@@ -1341,13 +1342,13 @@ classdef Sources2D < handle
             %   frame_range:  [frame_start, frame_end], the range of frames to be loaded
             %% Author: Pengcheng Zhou, Columbia University, 2017
             %% email: zhoupc1988@gmail.com
-            
+
             %% process parameters
-            
+
             try
                 % map data
                 mat_data = obj.P.mat_data;
-                
+
                 % dimension of data
                 dims = mat_data.dims;
                 d1 = dims(1);
@@ -1355,40 +1356,40 @@ classdef Sources2D < handle
                 T = dims(3);
                 obj.options.d1 = d1;
                 obj.options.d2 = d2;
-                
+
                 % parameters for patching information
                 patch_pos = mat_data.patch_pos;
                 block_pos = mat_data.block_pos;
-                
+
                 % number of patches
                 [nr_patch, nc_patch] = size(patch_pos);
             catch
                 error('No data file selected');
             end
-            
+
             if ~exist('frame_range', 'var')||isempty(frame_range)
                 frame_range = obj.frame_range;
             end
             % frames to be loaded for initialization
             T = diff(frame_range) + 1;
-            
+
             bg_model = obj.options.background_model;
             bg_ssub = obj.options.bg_ssub;
             % reconstruct the constant baseline
             if strcmpi(bg_model, 'ring')
                 b0_ = obj.reconstruct_b0();
-                b0_new_ = obj.reshape(obj.b0_new, 2); 
+                b0_new_ = obj.reshape(obj.b0_new, 2);
             end
-            
+
             %% start reconstructing the background
             RSS = cell(nr_patch, nc_patch);
             W_all = obj.W;
             b0_all = cell(nr_patch, nc_patch);  % including b0 within block
-            b0_all_new = b0_all; 
+            b0_all_new = b0_all;
             A_all = cell(nr_patch, nc_patch);
             C_all = cell(nr_patch, nc_patch);
-            A_all_prev = cell(nr_patch, nc_patch); 
-            C_all_prev = cell(nr_patch, nc_patch); 
+            A_all_prev = cell(nr_patch, nc_patch);
+            C_all_prev = cell(nr_patch, nc_patch);
             b_ = obj.b;
             f_ = obj.f;
             for mpatch=1:nr_patch*nc_patch
@@ -1411,48 +1412,48 @@ classdef Sources2D < handle
                     C_all_prev{mpatch} = obj.C_prev(ind, frame_range(1):frame_range(2));
                 end
             end
-            
+
             %%
            parfor mpatch=1:(nr_patch*nc_patch)
                 tmp_block = block_pos{mpatch};
                 tmp_patch = patch_pos{mpatch};
-                
+
                 if strcmpi(bg_model, 'ring')
                     W_ring = W_all{mpatch};
                     mask = zeros(d1, d2);
                     mask(tmp_block(1):tmp_block(2), tmp_block(3):tmp_block(4)) = 1;
                     mask(tmp_patch(1):tmp_patch(2), tmp_patch(3):tmp_patch(4)) = 2;
                     ind_patch = (mask(mask>0)==2);
-                    
+
                     %                     b0_ring = obj.b0{mpatch};
                     % load data
                     Ypatch = get_patch_data(mat_data, tmp_patch, frame_range, true);
                     [nr_block, nc_block, ~] = size(Ypatch);
                     Ypatch = reshape(Ypatch, [], T);
-                    
+
 %                     tmp_block = block_pos{mpatch};
 %                     tmp_patch = patch_pos{mpatch};
                     b0_ring = b0_all{mpatch};
                     b0_new_patch = b0_all_new{mpatch};
                     b0_ring = reshape(b0_ring, [], 1);
-%                     b0_new_patch = reshape(b0_new_patch, [], 1); 
-                    
+%                     b0_new_patch = reshape(b0_new_patch, [], 1);
+
                     % find the neurons that are within the block
                     A_patch = A_all{mpatch};
                     C_patch = C_all{mpatch};
-                    
+
                     A_patch_prev = A_all_prev{mpatch};
                     C_patch_prev = C_all_prev{mpatch};
-                    
+
                     % compute Y-A*C
                     YmAC = double(Ypatch(ind_patch, :)) -A_patch(ind_patch, :)*C_patch;
-                    b0_new_patch = reshape(b0_new_patch(ind_patch), [], 1); 
-                    
+                    b0_new_patch = reshape(b0_new_patch(ind_patch), [], 1);
+
                     % reconstruct background
                     Ypatch = bsxfun(@minus, double(Ypatch), b0_ring);
 %                     b0_ring = b0_all_patch{mpatch};
 %                     b0_ring = reshape(b0_ring, [], 1);
-                    if bg_ssub==1                        
+                    if bg_ssub==1
                         Bf = W_ring*(double(Ypatch) - A_patch_prev*C_patch_prev);
                     else
                         [d1s, d2s] = size(imresize(zeros(nr_block, nc_block), 1/bg_ssub));
@@ -1463,8 +1464,8 @@ classdef Sources2D < handle
                         Bf = Bf((tmp_patch(1):tmp_patch(2))-tmp_block(1)+1, (tmp_patch(3):tmp_patch(4))-tmp_block(3)+1, :);
                         Bf = reshape(Bf, [], T);
                     end
-%                     b0_ring = mean(YmAC, 2); 
-                    Ybg_patch = bsxfun(@plus, Bf, b0_new_patch); %, diff(tmp_patch(1:2))+1, [], T);                  
+%                     b0_ring = mean(YmAC, 2);
+                    Ybg_patch = bsxfun(@plus, Bf, b0_new_patch); %, diff(tmp_patch(1:2))+1, [], T);
                 elseif strcmpi(bg_model, 'nmf')
                     Ypatch = get_patch_data(mat_data, tmp_patch, frame_range, true);
                     YmAC = double(Ypatch) - A_all{mpatch}*C_all{mpatch};
@@ -1480,15 +1481,15 @@ classdef Sources2D < handle
                     Ybg_patch = bsxfun(@plus, b_svd*f_svd(:, frame_range(1):frame_range(2)), b0_svd);
                 end
                 RSS{mpatch} = sum((YmAC(:)-Ybg_patch(:)).^2);
-%                 temp = YmAC - Ybg_patch; 
-%                 RSS{mpatch} = sum(temp(:).^2)- size(temp,2)*sum(mean(temp, 2).^2); 
-                
+%                 temp = YmAC - Ybg_patch;
+%                 RSS{mpatch} = sum(temp(:).^2)- size(temp,2)*sum(mean(temp, 2).^2);
+
             end
             temp = cell2mat(RSS);
             RSS_total = sum(temp(:));
-            obj.P.RSS = RSS_total; 
+            obj.P.RSS = RSS_total;
         end
-        
+
         %% concateneate b, f, b0, W
         %         function Ybg = concatenate_var(obj)
         %             %% concatenate a signle variable for divided version of b, f, b0, W
@@ -1540,7 +1541,7 @@ classdef Sources2D < handle
         %             end
         %
         %         end
-        
+
         %% merge neurons
         function [img, col0, AA] = overlapA(obj, ind, ratio)
             %merge all neurons' spatial components into one singal image
@@ -1552,13 +1553,13 @@ classdef Sources2D < handle
             if nargin<3
                 ratio = 0.3;
             end
-            
+
             %             v_max = max(max(AA,1));
             v_max = 1;
             AA = bsxfun(@times, AA, v_max./max(AA,[],1));
             AA(bsxfun(@lt, AA, max(AA, [], 1)*ratio)) = 0;
             [d, K] = size(AA);
-            
+
             if K==2
                 col = [4, 2];
             elseif K==3
@@ -1576,7 +1577,7 @@ classdef Sources2D < handle
             img = img/max(img(:))*(2^16);
             img = uint16(img);
         end
-        
+
         %% play video
         function playAC(obj, avi_file, cell_id, indt)
             if nargin<3 || isempty(cell_id)
@@ -1603,7 +1604,7 @@ classdef Sources2D < handle
                 fp.FrameRate = obj.Fs;
                 fp.open();
             end
-            
+
             cmax = max(reshape(obj.A*obj.C, 1, []));
             for m=indt(1):indt(2)
                 img = obj.A(:, cell_id)*bsxfun(@times, obj.C(cell_id,m), col);
@@ -1621,7 +1622,7 @@ classdef Sources2D < handle
             end
             if nargin>1; fp.close(); end
         end
-        
+
         %% find neurons from the residual
         % you can do it in either manual or automatic way
         function [center, Cn, pnr] = pickNeurons(obj, Y, patch_par, seed_method, debug_on, K)
@@ -1650,15 +1651,15 @@ classdef Sources2D < handle
                 obj.P.kernel_pars = [obj.P.kernel_pars; neuron.P.kernel_pars];
             end
         end
-        
+
         %% post process spatial component
         A_ = post_process_spatial(obj, A_)
-        
+
         %% merge neruons
         [merged_ROIs, newIDs, obj_bk] = merge_high_corr(obj, show_merge, merge_thr);
         [merged_ROIs, newIDs, obj_bk] = merge_close_neighbors(obj, show_merge, merge_thr);
         [merged_ROIs, newIDs, obj_bk] = merge_neurons_dist_corr(obj, show_merge, merge_thr, dmin, method_dist, max_decay_diff);
-        
+
         %% tag neurons with quality control
         function tags_ = tag_neurons_parallel(obj, min_pnr)
             if ~exist('min_pnr', 'var') || isempty(min_pnr)
@@ -1670,27 +1671,27 @@ classdef Sources2D < handle
             K = size(A_, 2);
             tags_ = zeros(K, 1, 'like', uint16(0));
             min_pixel = obj.options.min_pixel;
-            
+
             % check the number of nonzero pixels
             nz_pixels = full(sum(A_>0, 1));
             tags_ = tags_ + uint16(nz_pixels'<min_pixel);
-            
+
             % check the number of calcium transients after the first frame
             if obj.options.deconv_flag
                 nz_spikes = full(sum(S_(:,2:end)>0, 2));
                 tags_ = tags_ + uint16(nz_spikes<1)*2;
-                
+
                 tmp_std = std(obj.C_raw-obj.C, 0, 2);
                 % check the noise level, it shouldn't be 0
                 temp= tmp_std./GetSn(obj.C_raw);
                 tags_ = tags_ + uint16(temp<0.1)*4;
-                
+
                 % check PNR of neural traces
                 pnrs = max(obj.C, [], 2)./tmp_std;
                 tags_ = tags_+uint16(pnrs<min_pnr)*8;
             end
-            
-            
+
+
             obj.tags = tags_;
         end
         %% estimate local background
@@ -1707,12 +1708,12 @@ classdef Sources2D < handle
             else
                 sn = obj.reshape(sn, 2);
             end
-            
+
             if ~exist('thresh', 'var')||isempty(thresh); thresh = []; end
             [Ybg, results] = local_background(obj.reshape(Ybg, 2), ssub, rr, IND, sn, thresh);
             Ybg = obj.reshape(Ybg, 1);
         end
-        
+
         %% save results
         function save_results(obj, file_nm, Ybg) %#ok<INUSD>
             warning('off', 'all');
@@ -1725,7 +1726,7 @@ classdef Sources2D < handle
             warning('on', 'all');
             fprintf('results has been saved into file %s\n', file_nm);
         end
-        
+
         %% reconstruct background signal given the weights
         function Ybg = reconstructBG(obj, Y, weights)
             if ~exist('weights', 'var')||isempty(weights)
@@ -1755,11 +1756,11 @@ classdef Sources2D < handle
             % detect events by thresholding S with sig*noise
             % can get at most one spike
             % sig: threshold of the minimum amplitude of the events
-            
+
             if ~exist('sig', 'var')|| isempty(sig)
                 sig=5;
             end
-            
+
             if ~exist('w', 'var')||isempty(w)
                 w = obj.Fs;
             end
@@ -1771,11 +1772,11 @@ classdef Sources2D < handle
                 E(m, E(m, :)-Emin(m, :)< obj.P.neuron_sn{m}*sig) = 0; % remove small transients
             end
         end
-        
+
         %% save results
         function file_path = save_workspace(obj)
             fprintf('------------- SAVE THE WHOLE WORKSPACE ----------\n\n');
-            
+
             obj.compress_results();
             file_path = [obj.P.log_folder,  strrep(get_date(), ' ', '_'), '.mat'];
             evalin('caller', sprintf('save(''%s'', ''neuron'', ''save_*'', ''show_*'', ''use_parallel'', ''with_*'', ''-v7.3''); ', file_path));
@@ -1785,9 +1786,9 @@ classdef Sources2D < handle
                 fprintf('The current workspace has been saved into file \n\t%s\n\n', file_path);
                 fp.close();
             end
-            
+
         end
-        
+
         %% save results for all batches
         function file_paths = save_workspace_batch(obj, log_folder)
             if ~exist('log_folder', 'var')||isempty(log_folder)||(~exist(log_folder, 'dir'))
@@ -1796,17 +1797,17 @@ classdef Sources2D < handle
             obj.P.log_folder = log_folder;
             nbatches = length(obj.batches);
             file_paths = cell(nbatches, 1);
-            
+
             for mbatch=1:nbatches
                 batch_k = obj.batches{mbatch};
                 neuron = batch_k.neuron;
-                
+
                 fprintf('\nprocessing batch %d/%d\n', mbatch, nbatches);
-                
+
                 % update background
                 neuron.compress_results();
                 file_path = [neuron.P.log_folder,  strrep(get_date(), ' ', '_'), '.mat'];
-                
+
                 save(file_path, 'neuron');
                 try
                     fp = fopen(neuron.P.log_file, 'a');
@@ -1815,12 +1816,12 @@ classdef Sources2D < handle
                     fp.close();
                 end
                 file_paths{mbatch} = file_path;
-                
+
             end
             obj.P.file_paths = file_paths;
             obj.save_workspace();
         end
-        
+
         %% clean the log folders
         function clean_results(obj)
             if ~isempty(obj.batches)
@@ -1833,16 +1834,16 @@ classdef Sources2D < handle
                 fprintf('file deletion failed\n');
             end
         end
-        
+
         %% clean the log folders for all patch
         function clean_results_batch(obj)
             nbatches = length(obj.batches);
             for mbatch=1:nbatches
                 batch_k = obj.batches{mbatch};
                 neuron_k = batch_k.neuron;
-                
+
                 fprintf('\nprocessing batch %d/%d\n', mbatch, nbatches);
-                
+
                 % update background
                 neuron_k.clean_results();
             end
@@ -1855,15 +1856,15 @@ classdef Sources2D < handle
                 obj.W = sparse(obj.W);
             end
         end
-        
+
         %% compute correlation image and PNR image
         function [Cn, PNR] = correlation_pnr(obj, Y)
             [Cn, PNR] = correlation_image_endoscope(Y, obj.options);
         end
-        
+
         %% compute correlation image and peak to noise ratio in parallel
         [Cn, PNR] = correlation_pnr_parallel(obj, frame_range)
-        
+
         %% compute correlation image and PNR image for each batch
         function correlation_pnr_batch(obj)
             nbatches = length(obj.batches);
@@ -1875,9 +1876,9 @@ classdef Sources2D < handle
                 batch_k.neuron = neuron_k;
                 obj.batches{mbatch} = batch_k;
             end
-            
+
         end
-        
+
         %% convert struct data to Sources2D object
         function obj = struct2obj(obj, var_struct)
             temp = fieldnames(var_struct);
@@ -1887,7 +1888,7 @@ classdef Sources2D < handle
                 end
             end
         end
-        
+
         %% convert Sources2D object to a struct variable
         function neuron = obj2struct(obj, ind)
             if ~exist('ind', 'var') || isempty(ind)
@@ -1916,9 +1917,9 @@ classdef Sources2D < handle
                 neuron.ids = obj.ids(ind);
                 neuron.tags = obj.tags(ind);
             end
-            
+
         end
-        
+
         %% show contours of the all neurons
         function Coor = show_contours(obj, thr, ind, img, with_label)
             %% show neuron contours
@@ -1940,11 +1941,11 @@ classdef Sources2D < handle
             if ~exist('img', 'var') || isempty(img)
                 img = obj.Cn;
             end
-            
+
             if ~exist('with_label', 'var') || isempty(with_label)
                 with_label = false;
             end
-            
+
             if isempty(obj.Coor) || (length(obj.Coor)~=K)
                 Coor = obj.get_contours(thr);
                 obj.Coor = Coor;
@@ -1960,7 +1961,7 @@ classdef Sources2D < handle
                 saveas(gcf, file_path);
             end
         end
-        
+
         %% get contours of the all neurons
         function Coor = get_contours(obj, thr, ind_show)
             A_ = obj.A;
@@ -1986,14 +1987,14 @@ classdef Sources2D < handle
                 % smooth the image with median filter
                 A_temp = obj.reshape(full(A_(:, m)),2);
                 % find the threshold for detecting nonzero pixels
-                
+
                 A_temp = A_temp(:);
                 [temp,ind] = sort(A_temp(:).^2,'ascend');
                 temp =  cumsum(temp);
                 ff = find(temp > (1-thr)*temp(end),1,'first');
                 thr_a = A_temp(ind(ff));
                 A_temp = obj.reshape(A_temp,2);
-                
+
                 % crop a small region for computing contours
                 [tmp1, tmp2, ~] = find(A_temp);
                 if isempty(tmp1)
@@ -2005,13 +2006,13 @@ classdef Sources2D < handle
                 cmin = max(1, min(tmp2)-3);
                 cmax = min(d2, max(tmp2)+3);
                 A_temp = A_temp(rmin:rmax, cmin:cmax);
-                
+
                 l = bwlabel(medfilt2(A_temp>thr_a));
                 l_most = mode(l(l>0));
-                ind = (l==l_most); 
-                A_temp(ind) =  max(A_temp(ind), thr_a); 
-                A_temp(~ind) = min(A_temp(~ind), thr_a*0.99); 
-                
+                ind = (l==l_most);
+                A_temp(ind) =  max(A_temp(ind), thr_a);
+                A_temp(~ind) = min(A_temp(~ind), thr_a*0.99);
+
                 pvpairs = { 'LevelList' , thr_a, 'ZData', A_temp};
                 h = matlab.graphics.chart.primitive.Contour(pvpairs{:});
                 temp = h.ContourMatrix;
@@ -2025,10 +2026,10 @@ classdef Sources2D < handle
                     temp(:, 1) = temp(:, end);
                     Coor{m} = bsxfun(@plus, temp, [cmin-1; rmin-1]);
                 end
-                
+
             end
         end
-        
+
         %% manually draw ROI and show the mean fluorescence traces within the ROI
         function y = drawROI(obj, Y, img, type)
             Y = obj.reshape(Y,1);
@@ -2064,13 +2065,13 @@ classdef Sources2D < handle
                 plot(y);
             end
         end
-        %% determine the number of neurons within each patch 
+        %% determine the number of neurons within each patch
         function nn = ids_per_patch(obj)
-            % calculate how many neurons in each patch 
+            % calculate how many neurons in each patch
             try
                 % map data
                 mat_data = obj.P.mat_data;
-                
+
                 % dimension of data
                 dims = mat_data.dims;
                 d1 = dims(1);
@@ -2078,7 +2079,7 @@ classdef Sources2D < handle
                 T = dims(3);
                 obj.options.d1 = d1;
                 obj.options.d2 = d2;
-                
+
                 % parameters for patching information
                 patch_pos = mat_data.patch_pos;
                 % number of patches
@@ -2086,24 +2087,24 @@ classdef Sources2D < handle
             catch
                 error('No data file selected');
             end
-            
-            nn = cell(size(obj.b)); 
+
+            nn = cell(size(obj.b));
             for mpatch=1:(nr_patch*nc_patch)
                 tmp_patch = patch_pos{mpatch};
                 r0 = tmp_patch(1);
                 r1 = tmp_patch(2);
                 c0 = tmp_patch(3);
                 c1 = tmp_patch(4);
-                ind = false(d1,d2); 
+                ind = false(d1,d2);
                 ind(r0:r1, c0:c1) = true;
-                nn{mpatch} = obj.ids(sum(obj.A(ind, :), 1)>0); 
+                nn{mpatch} = obj.ids(sum(obj.A(ind, :), 1)>0);
             end
-            obj.neurons_per_patch = nn; 
+            obj.neurons_per_patch = nn;
         end
-        
-        
-     
-        
+
+
+
+
     end
-    
+
 end


### PR DESCRIPTION
A bug in `reconstruct_background` has a bug in it, where reconstructing the background in each batch neuron using a frame range of `batch_neuron.reconstruct_background([1 size(C_raw, 2)]);` will cause the same background to be reconstructed from the first batch neuron, for every batch neuron. This bug fix allows each batch neuron to sample from the correct frame range to reconstruct the background.

See line 1265 in Sources2D.m

Please disregard all the white-space changes, that's an artifact of my code editor.